### PR TITLE
Fix a bug while using browser without SAB

### DIFF
--- a/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
@@ -264,7 +264,7 @@ const processor = (processorId, paramsConfig) => {
 			});
 			this.unlock();
 			if (!this.supportSharedArrayBuffer) {
-				this.call('setBuffer', { buffer: { lock: this.$lock, paramsBuffer: this.$internalParamsBuffer } });
+				this.call('setBuffer', { lock: this.$lock, paramsBuffer: this.$internalParamsBuffer });
 			}
 			const { currentTime } = audioWorkletGlobalScope;
 			let $event;


### PR DESCRIPTION
the `setBuffer` argument was mismatched.