### PR TITLE
add cors:* so plugins can be loaded from another host

### DIFF
--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "parcel-bundler": "^1.12.4",
     "pingpongdelay": "^0.0.0",

--- a/packages/host/server.js
+++ b/packages/host/server.js
@@ -1,6 +1,6 @@
 const Bundler = require('parcel-bundler');
 const express = require('express');
-
+var cors = require('cors')
 const app = express();
 
 // fix : https://github.com/parcel-bundler/parcel/issues/1315#issuecomment-523524186
@@ -9,6 +9,7 @@ app.get('/', (req, res, next) => {
 	next();
 });
 
+app.use(cors())
 app.use('/packages', express.static('../'));
 
 const bundler = new Bundler('src/*.html');

--- a/packages/host/src/main.js
+++ b/packages/host/src/main.js
@@ -51,7 +51,6 @@ Array.from(examples).forEach((example) => {
 let state;
 
 const setPlugin = async (pluginUrl) => {
-	console.log("setPlugin start")
 	// Load plugin from the url of its json descriptor
 	// Pass the option { noGui: true } to not load the GUI by default
 	// IMPORTANT NOTICE :
@@ -79,8 +78,6 @@ const setPlugin = async (pluginUrl) => {
 
 	audioContext.resume();
 	//player.play();
-
-	console.log("setPlugin 4")
 
 	// Load the GUI if need (ie. if the option noGui was set to true)
 	// And calls the method createElement of the Gui module

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,6 +5194,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^5.0.0, cosmiconfig@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -9993,7 +10001,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -13673,7 +13681,7 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
Disables CORS to open the `webaudiomodule` host to serve the WAM plugins to other origins.  

Wouldn't be great to run in production like this, but I think fine for development purpose?