### PR TITLE
Do minimum work inside ParamMgr onChange callback

### DIFF
--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -237,19 +237,18 @@ export default class ParamMgrNode extends AudioWorkletNode {
 		if (typeof this.paramsUpdateCheckFnRef[i] === 'number') {
 			window.clearTimeout(this.paramsUpdateCheckFnRef[i]);
 		}
-		this.paramsUpdateCheckFn[i] = this.paramUpdateCallback.bind(this, i, onChange, interval)
-		
-		this.paramsUpdateCheckFn[i]()		
-	}
 
-	paramUpdateCallback = (index, onChange, interval) => {
-		const prev = this.$prevParamsBuffer[index];
-		const cur = this.$paramsBuffer[index];
-		if (cur !== prev) {
-			onChange(cur, prev);
-			this.$prevParamsBuffer[index] = cur;
+		this.paramsUpdateCheckFn[i] = () => {
+			const prev = this.$prevParamsBuffer[i];
+			const cur = this.$paramsBuffer[i];
+			if (cur !== prev) {
+				onChange(cur, prev);
+				this.$prevParamsBuffer[i] = cur;
+			}
+			this.paramsUpdateCheckFnRef[i] = window.setTimeout(this.paramsUpdateCheckFn[i], interval)
 		}
-		this.paramsUpdateCheckFnRef[index] = window.setTimeout(this.paramsUpdateCheckFn[index], interval)
+		
+		this.paramsUpdateCheckFn[i]()
 	}
 
 	/**

--- a/packages/sdk/src/ParamMgr/types.d.ts
+++ b/packages/sdk/src/ParamMgr/types.d.ts
@@ -191,19 +191,20 @@ export interface ParamMgrNode<Params extends string = string, InternalParams ext
      * @deprecated
      */
     readonly $prevParamsBuffer: Float32Array;
-    /**
-     * A set for internal parameters names.
-     * These params is ready for next change event dispatch.
-     * (to throttle event dispatch rate for the non-AudioParam internal parameters)
-     * @deprecated
-     */
-    readonly paramsChangeCanDispatch: Set<InternalParams>;
+
     /**
      * Event dispatch callbacks reference of the `setTimeout` calls.
      * Used to clear the callbacks while destroying the plugin.
      * @deprecated
      */
     readonly paramsUpdateCheckFnRef: number[];
+
+    /**
+     * Event dispatch callback functions bound to specific values for the parameter.
+     * @deprecated
+     */
+    readonly paramsUpdateCheckFn: number[];
+
     /**
      * waiting for the processor that gives the `paramsBuffer` `SharedArrayBuffer`
      */


### PR DESCRIPTION
This PR reduces the amount of work done inside ParamMgr when it is polling for parameter changes and possibly calling the parameter's `onChange` callback.

`requestDispatchIParamChange` is called once, upon initialization.  It does all of the checks to ensure we want to start polling the parameter, and then it stores a reference to `paramUpdateCallback` bound to the specific values for this callback handler.  `paramUpdateCallback` does the least work possible - compares new and old values, calls onChange if necessary, reschedules itself.

By doing so it avoids creating new closures, and avoids re-doing all the sanity checks done in `requestDispatchIParamChange`, a number of which are O(n) on the number of parameters in the plugin.

In terms of performance improvement, on my 2.3 GHz i7 running Chrome 89.0.4389.90 I see a top-line difference of ~4.8% less time spent in main-thread scripting when sequencing 8 instances of Synth-101.  

Without this PR applied:
<img width="329" alt="image" src="https://user-images.githubusercontent.com/699550/112867386-de08c200-9088-11eb-9bd8-5f4cda5549fc.png">

With this PR applied:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/699550/112867420-e95bed80-9088-11eb-8531-341930a0378a.png">

Complete Chrome performance profiles are attached:
[callback_changes_perf.zip](https://github.com/53js/webaudiomodule/files/6223087/callback_changes_perf.zip)

My biggest takeaway is that `onChange` should be avoided as much as possible, which is pretty obvious.  Working on moving Synth-101 away from onChange almost entirely, but still thought this PR worthwhile.