### PR TITLE
adds destroyGui function for plugins that need explicit cleanup

### DIFF
--- a/packages/host/src/main.js
+++ b/packages/host/src/main.js
@@ -15,6 +15,7 @@ const audioContext = new AudioContext();
 const mediaElementSource = audioContext.createMediaElementSource(player);
 
 let currentPluginAudioNode, liveInputGainNode;
+let currentPluginDomNode;
 
 // Very simple function to connect the plugin audionode to the host
 const connectPlugin = (audioNode) => {
@@ -70,6 +71,11 @@ const setPlugin = async (pluginUrl) => {
 			feedback: 0.7,
 		},
 	});
+
+	if (window.instance && currentPluginDomNode && window.instance.destroyGui) {
+		window.instance.destroyGui(currentPluginDomNode)
+	}
+
 	window.instance = instance;
 	// instance.enable();
 
@@ -81,14 +87,14 @@ const setPlugin = async (pluginUrl) => {
 
 	// Load the GUI if need (ie. if the option noGui was set to true)
 	// And calls the method createElement of the Gui module
-	const pluginDomNode = await instance.createGui();
+	currentPluginDomNode = await instance.createGui();
 
 	// Show plugin info
-	showPluginInfo(instance, pluginDomNode);
+	showPluginInfo(instance, currentPluginDomNode);
 
 	populateParamSelector(instance);
 
-	mountPlugin(pluginDomNode);
+	mountPlugin(currentPluginDomNode);
 
 	const saveStateButton = document.querySelector('#saveStateButton');
 	const restoreStateButton = document.querySelector('#restoreStateButton');

--- a/packages/sdk/src/api/types.d.ts
+++ b/packages/sdk/src/api/types.d.ts
@@ -46,6 +46,9 @@ export interface WebAudioModule<Node extends WamNode = WamNode> {
     initialize(state?: any): Promise<WebAudioModule>;
     /** Redefine this method to get the WAM's GUI as an HTML `Element`. */
     createGui(): Promise<Element>;
+
+    /** Clean up an element previously returned by `createGui` */
+    destroyGui?(gui: Element): void
 }
 export const WebAudioModule: {
     prototype: WebAudioModule;

--- a/packages/synth101/src/SynthView.tsx
+++ b/packages/synth101/src/SynthView.tsx
@@ -30,6 +30,7 @@ export interface SynthViewProps {
   
     // Lifecycle: Called just before our component will be destroyed
     componentWillUnmount() {
+      console.log("Synth-101 unmounting")
     }
   
     detuneChanged(value: number) {

--- a/packages/synth101/src/index.tsx
+++ b/packages/synth101/src/index.tsx
@@ -275,14 +275,18 @@ export default class Synth101 extends WebAudioModule<Synth101Node> {
     }
 
 	async createGui() {
-		// return new Promise<Element>((resolve, reject) => {
-			const div = document.createElement('div');
-			// hack because h() is getting stripped for non-use despite it being what the JSX compiles to
-			h("div", {})
+		const div = document.createElement('div');
+		// hack because h() is getting stripped for non-use despite it being what the JSX compiles to
+		h("div", {})
 
-    		render(<SynthView plugin={this}></SynthView>, div);
+		var shadow = div.attachShadow({mode: 'open'});
+		render(<SynthView plugin={this}></SynthView>, shadow);
 
-   			return div;
-		// })
+		return div;
+	}
+
+	destroyGui(el: Element) {
+		console.log("destroyGui called!")
+		render(null, el.shadowRoot)
 	}
 }


### PR DESCRIPTION
With some common render libraries like React and Preact, once you render into a DOM node, even if you remove the DOM node from the document, the library keeps the rendered components alive until you explicitly erase them.

If you want to see the problem, take any React rendered plugin on the master branch, and add a log statement on `componentWillUnmount`.  You will see it does not get unmounted when the DOM node is replaced by loading a different plugin.