### PR TITLE
Fix 2 synchronization issues with ParamMgr

### DIFF
--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -223,11 +223,16 @@ export default class ParamMgrNode extends AudioWorkletNode {
 	}
 
 	getState() {
-		return this.getParameterValues();
+		return new Promise((resolve) => {
+			resolve(this.getParamsValues());
+		});
 	}
 
 	setState(state) {
-		return this.setParameterValues(state);
+		return new Promise((resolve) => {
+			this.setParamsValues(state);
+			resolve();
+		});
 	}
 
 	convertTimeToFrame(time) {

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -46,6 +46,7 @@ export default class ParamMgrNode extends AudioWorkletNode {
 		this.$prevParamsBuffer = new Float32Array(this.internalParams.length);
 		this.paramsUpdateCheckFn = [];
 		this.paramsUpdateCheckFnRef = [];
+		this.messageRequestId = 0;
 
 		Object.entries(this.getParams()).forEach(([name, param]) => {
 			Object.setPrototypeOf(param, MgrAudioParam.prototype);
@@ -60,12 +61,15 @@ export default class ParamMgrNode extends AudioWorkletNode {
 		 * @param {keyof ParamMgrCallToProcessor} call
 		 * @param {any} args
 		 */
-		this.call = (call, ...args) => new Promise((resolve, reject) => {
-			const id = performance.now();
-			resolves[id] = resolve;
-			rejects[id] = reject;
-			this.port.postMessage({ id, call, args });
-		});
+		this.call = (call, ...args) => {
+			const id = this.messageRequestId;
+			this.messageRequestId += 1;
+			return new Promise((resolve, reject) => {
+				resolves[id] = resolve;
+				rejects[id] = reject;
+				this.port.postMessage({ id, call, args });
+			});
+		};
 		this.handleMessage = ({ data }) => {
 			const { id, call, args, value, error } = data;
 			if (call) {


### PR DESCRIPTION
**Issue 1: ParamMgr.getState() needs to reflect changes made by ParamMgr.setState()**

In ParamMgrNode, getState() was calling `getParameterValues()` which calls into the audio thread, while `setState` calling `setParameterValues()` was setting variables in the main thread.  This can cause sync issues where setting a value and then calling `getState()` would result in stale data, or calling `setState()` followed by `getState()` would not reflect the changes made in `setState()`.

In this proposed fix I make both `getState()` and `setState()` only interact with the main thread variables as it seems they take precedence in most of ParamMgrNode, but if I'm mistaken another fix would be to make `setParameterValues()` also call into the audio thread, and ensure variable syncronization has occurred before returning.

**Issue 2: performance.now() is not safe as an id, can cause collisions**

In my host, I had 3 separate "modulators" connecting to the same ParamMgr-based WAM.  All 3 run the same codepath at basically the same time when loading the project, so the one WAM receives 3 calls at about the same time. In this instance I was experiencing `performance.now()` return the same value on a second call while the first call was still in flight, so the second call would get the result of both promises and the first call would never resolve.