### PR TITLE
try without catch does not swallow errors

### DIFF
--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -125,6 +125,7 @@ export default class ParamMgrNode extends AudioWorkletNode {
 			if (config instanceof AudioParam) {
 				try {
 					config.automationRate = 'a-rate';
+				} catch {
 				} finally {
 					config.value = Math.max(0, config.minValue);
 					this.connect(config, offset + i);


### PR DESCRIPTION
Without a catch, try..finally will still raise the error up the chain.

Hit this in Chrome while automating a compressor's threshold audioparam.

Note that catch with no parameter is an ES2019 feature https://2ality.com/2017/08/optional-catch-binding.html

If you'd like me to update to an empty `catch(e)` just let me know.