### PR TITLE
Param info event

### DIFF
--- a/packages/WamExample/src/Gui/Gui.js
+++ b/packages/WamExample/src/Gui/Gui.js
@@ -136,9 +136,9 @@ const style = `.pedal {
 	position: absolute;
 	margin: auto;
 	color: #333333;
-	font-family: "Helvetica";
+	font-family: "Apple Chancery";
 	font-size: 18px;
-	font-style: bold;
+	font-weight: bold;
 	text-align: center;
 }
 

--- a/packages/host/src/main.js
+++ b/packages/host/src/main.js
@@ -43,8 +43,12 @@ let liveInputGainNode;
  * @param {WamNode} audioNode
  */
 const connectPlugin = (audioNode) => {
-	// eslint-disable-next-line no-use-before-define
-	const handleParameterInfo = () => populateParamSelector(currentPluginAudioNode);
+	const handleInfoEvent = (i) => {
+		const { data } = i.detail;
+		if (data.instanceId === currentPluginAudioNode.instanceId) {
+			populateParamSelector(currentPluginAudioNode);
+		}
+	};
 	if (currentPluginAudioNode) {
 		liveInputGainNode.disconnect();
 		if (keyboardPluginAudioNode) {
@@ -53,7 +57,7 @@ const connectPlugin = (audioNode) => {
 		}
 		mediaElementSource.disconnect(currentPluginAudioNode);
 		currentPluginAudioNode.disconnect(audioContext.destination);
-		currentPluginAudioNode.removeEventListener('wam-parameter-info', handleParameterInfo);
+		currentPluginAudioNode.removeEventListener('wam-info', handleInfoEvent);
 		currentPluginAudioNode.destroy();
 		if (currentPluginDomNode) {
 			currentPluginAudioNode.module.destroyGui(currentPluginDomNode);
@@ -73,7 +77,7 @@ const connectPlugin = (audioNode) => {
 	if (audioNode.numberOfInputs) mediaElementSource.connect(audioNode);
 	audioNode.connect(audioContext.destination);
 	currentPluginAudioNode = audioNode;
-	currentPluginAudioNode.addEventListener('wam-parameter-info', handleParameterInfo);
+	currentPluginAudioNode.addEventListener('wam-info', handleInfoEvent);
 };
 
 /**

--- a/packages/pedalboard/src/audio/WamNode.js
+++ b/packages/pedalboard/src/audio/WamNode.js
@@ -8,7 +8,7 @@
  * @typedef {import('sdk/src/api/types').WamEvent} WamEvent
  * @typedef {import('sdk/src/api/types').WamEventMap} WamEventMap
  * @typedef {import('sdk/src/api/types').WamEventType} WamEventType
- * @typedef {import('sdk/src/api/types').WamParameterInfoEvent} WamParameterInfoEvent
+ * @typedef {import('sdk/src/api/types').WamInfoEvent} WamInfoEvent
  * @typedef {import('sdk/src/api/types').WamParameterConfiguration} WamParameterConfiguration
  */
 //@ts-check
@@ -102,13 +102,12 @@ export default class WamNode extends AudioWorkletNode {
 					this._parameterInfoMap.push({ instanceId, parameterId });
 				});
 			}
-			const parameterInfo = await this.getParameterInfo();
-			const parameterIds = Object.keys(parameterInfo);
+			const data = { instanceId: this.instanceId };
 			await this._call('updatePluginList', workletPluginList);
-			await this._call('updateParameterInfo', parameterIds);
-			/** @type {CustomEvent<WamParameterInfoEvent>} */
-			const wamParameterInfoEvent = new CustomEvent('wam-parameter-info', { detail: { type: 'wam-parameter-info', data: parameterIds, time: this.context.currentTime } });
-			this.pedalboardNode.dispatchEvent(wamParameterInfoEvent);
+			await this._call('updateParameterInfo', data);
+			/** @type {CustomEvent<WamInfoEvent>} */
+			const wamInfoEvent = new CustomEvent('wam-info', { detail: { type: 'wam-info', data, time: this.context.currentTime } });
+			this.pedalboardNode.dispatchEvent(wamInfoEvent);
 		};
 		this.pedalboardNode.addEventListener('change', this.handlePedalboardChange);
 	}

--- a/packages/pedalboard/src/audio/WamProcessor.js
+++ b/packages/pedalboard/src/audio/WamProcessor.js
@@ -4,6 +4,7 @@
  * @typedef {import('sdk/src/api/types').WamNodeOptions} WamNodeOptions
  * @typedef {import('sdk/src/api/types').WamParameterInfoMap} WamParameterInfoMap
  * @typedef {import('sdk/src/api/types').WamEvent} WamEvent
+ * @typedef {import('sdk/src/api/types').WamInfoData} WamInfoData
  * @typedef {import('sdk/src/ParamMgr/TypedAudioWorklet')
  * .AudioWorkletGlobalScope} AudioWorkletGlobalScope
  */
@@ -147,11 +148,11 @@ const processor = (processorId) => {
 		}
 
 		/**
-		 * @param {string[]} data
+		 * @param {WamInfoData} data
 		 */
 		updateParameterInfo(data) {
 			const { currentTime } = audioWorkletGlobalScope;
-			this.emitEvents({ type: 'wam-parameter-info', data, time: currentTime });
+			this.emitEvents({ type: 'wam-info', data, time: currentTime });
 		}
 
 		getCompensationDelay() {

--- a/packages/sdk/__test__/WamEventRingBuffer.spec.ts
+++ b/packages/sdk/__test__/WamEventRingBuffer.spec.ts
@@ -17,11 +17,7 @@ ensureTextEncoderDecoder(); // jest / JSDOM doesn't currently have these globals
 
 describe('WamEventRingBuffer Suite', () => {
 	const binaryBytesLength = 72;
-	const parameterIndices = {
-		x: 0,
-		y: 1,
-		z: 2,
-	};
+	const parameterIds = ['x', 'y', 'z'];
 
 	const inputAutomationEvent: WamAutomationEvent = {
 		type: 'wam-automation',
@@ -97,7 +93,7 @@ describe('WamEventRingBuffer Suite', () => {
 		}
 	}
 
-	it('Should handle updating parameter indices', () => {
+	it('Should handle updating parameter ids', () => {
 		const xAutomationEvent: WamAutomationEvent = {
 			type: 'wam-automation',
 			time: 10 * Math.random(),
@@ -145,7 +141,7 @@ describe('WamEventRingBuffer Suite', () => {
 		];
 
 		const sab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer, inputEvents.length);
-		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIndices, binaryBytesLength);
+		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIds, binaryBytesLength);
 
 		let numWritten = test.write(...inputEvents);
 		expect(numWritten).toEqual(inputEvents.length - 2);
@@ -161,14 +157,9 @@ describe('WamEventRingBuffer Suite', () => {
 		expect(numRead).toEqual(numWritten);
 		expect(outputEvents).toEqual(expectedOutputEvents);
 
-		const newParameterIndices = {
-			a: 0,
-			b: 1,
-			y: 2,
-			z: 3,
-		};
+		const newParameterIds = ['a', 'b', 'y', 'z'];
 
-		test.setParameterIndices(newParameterIndices);
+		test.setParameterIds(newParameterIds);
 
 		numWritten = test.write(...inputEvents);
 		expect(numWritten).toEqual(inputEvents.length - 1);
@@ -183,6 +174,23 @@ describe('WamEventRingBuffer Suite', () => {
 		outputEvents = test.read();
 		numRead = outputEvents.length;
 		expect(numRead).toEqual(numWritten);
+		expect(outputEvents).toEqual(expectedOutputEvents);
+
+		test.setParameterIds(parameterIds);
+
+		numWritten = test.write(...inputEvents);
+		expect(numWritten).toEqual(inputEvents.length - 2);
+
+		test.setParameterIds(newParameterIds);
+
+		expectedOutputEvents = [
+			yAutomationEvent,
+			zAutomationEvent,
+		];
+
+		outputEvents = test.read();
+		numRead = outputEvents.length;
+		expect(numRead).toEqual(numWritten - 1);
 		expect(outputEvents).toEqual(expectedOutputEvents);
 	});
 
@@ -211,7 +219,7 @@ describe('WamEventRingBuffer Suite', () => {
 		];
 
 		const sab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer, 1);
-		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIndices, binaryBytesLength);
+		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIds, binaryBytesLength);
 
 		const numWritten = test.write(...inputEvents);
 		expect(numWritten).toEqual(1);
@@ -231,7 +239,7 @@ describe('WamEventRingBuffer Suite', () => {
 		let read: WamEvent[] = [];
 
 		const sab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer, 1, binaryBytesLength);
-		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIndices, binaryBytesLength);
+		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIds, binaryBytesLength);
 
 		inputEvents.forEach((inputEvent) => {
 			written = test.write(inputEvent);
@@ -259,7 +267,7 @@ describe('WamEventRingBuffer Suite', () => {
 
 		const sab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer,
 			numEvents, binaryBytesLength);
-		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIndices, binaryBytesLength);
+		const test = new WamEventRingBuffer(RingBuffer, sab, parameterIds, binaryBytesLength);
 
 		test.write(...inputEvents);
 		const outputEvents = test.read();

--- a/packages/sdk/__test__/WamEventRingBuffer.spec.ts
+++ b/packages/sdk/__test__/WamEventRingBuffer.spec.ts
@@ -2,10 +2,10 @@
 /* eslint-disable no-plusplus */
 
 import expect from './jestUtilities';
-import { shuffleArray } from './testUtilities';
+import { shuffleArray, ensureTextEncoderDecoder } from './testUtilities';
 import {
 	WamEvent, WamAutomationEvent, WamTransportEvent,
-	WamMidiEvent, WamMpeEvent, WamSysexEvent, WamOscEvent,
+	WamMidiEvent, WamMpeEvent, WamSysexEvent, WamOscEvent, WamInfoEvent
 } from '../src/api/types';
 
 import getRingBuffer from '../src/RingBuffer.js';
@@ -88,6 +88,14 @@ describe('WamEventRingBuffer Suite', () => {
 			bytes: sysexBytes,
 		},
 	};
+
+	const inputInfoEvent: WamInfoEvent = {
+		type: 'wam-info',
+		time: 10 * Math.random(),
+		data: {
+			instanceId: `some-wam-name.instance.${Date.now().toString()}`,
+		}
+	}
 
 	it('Should handle updating parameter indices', () => {
 		const xAutomationEvent: WamAutomationEvent = {
@@ -198,8 +206,8 @@ describe('WamEventRingBuffer Suite', () => {
 
 	it('Should only write number of events for which there is enough space', () => {
 		const inputEvents = [
-			inputTransportEvent,
-			inputTransportEvent,
+			inputSysexEvent,
+			inputSysexEvent,
 		];
 
 		const sab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer, 1);
@@ -217,6 +225,7 @@ describe('WamEventRingBuffer Suite', () => {
 			inputMpeEvent,
 			inputSysexEvent,
 			inputOscEvent,
+			inputInfoEvent,
 		];
 		let written = 0;
 		let read: WamEvent[] = [];
@@ -242,6 +251,7 @@ describe('WamEventRingBuffer Suite', () => {
 			inputMpeEvent,
 			inputSysexEvent,
 			inputOscEvent,
+			inputInfoEvent,
 		];
 		const numEvents = inputEvents.length;
 

--- a/packages/sdk/__test__/testUtilities.ts
+++ b/packages/sdk/__test__/testUtilities.ts
@@ -46,3 +46,12 @@ export function shuffleArray(arrayLike: ArrayLike<any>) {
 			arrayLike[currentIndex]];
 	}
 }
+
+export function ensureTextEncoderDecoder() {
+	if (typeof TextEncoder === "undefined") {
+		globalThis.TextEncoder = require('util').TextEncoder;
+	}
+	if (typeof TextDecoder === "undefined") {
+		globalThis.TextDecoder = require('util').TextDecoder;
+	}
+}

--- a/packages/sdk/src/WamNode.js
+++ b/packages/sdk/src/WamNode.js
@@ -51,7 +51,7 @@ export default class WamNode extends AudioWorkletNode {
 		/** @type {number} */
 		this._messageId = 1;
 		/** @type {Set<WamEventType>} */
-		this._supportedEventTypes = new Set(['wam-event', 'wam-automation', 'wam-transport', 'wam-midi', 'wam-sysex', 'wam-mpe', 'wam-osc']);
+		this._supportedEventTypes = new Set(['wam-automation', 'wam-transport', 'wam-midi', 'wam-sysex', 'wam-mpe', 'wam-osc']);
 
 		this.port.onmessage = this._onMessage.bind(this);
 	}

--- a/packages/sdk/src/WamNode.js
+++ b/packages/sdk/src/WamNode.js
@@ -304,10 +304,14 @@ export default class WamNode extends AudioWorkletNode {
 			// else console.log(`unhandled message | response: ${response} content: ${content}`);
 		} else if (sab) {
 			this._useSab = true;
-			const { eventCapacity, parameterIndices } = sab;
+			const { eventCapacity, parameterIds } = sab;
 
-			/** @private @type {{[parameterId: string]: number}} */
-			this._parameterIndices = parameterIndices;
+			if (this._sabReady) {
+				// if parameter set changes after initialization
+				this._eventWriter.setParameterIds(parameterIds);
+				this._eventReader.setParameterIds(parameterIds);
+				return;
+			}
 
 			/** @private @type {SharedArrayBuffer} */
 			this._mainToAudioSab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer,
@@ -319,10 +323,10 @@ export default class WamNode extends AudioWorkletNode {
 
 			/** @private @type {WamEventRingBuffer} */
 			this._eventWriter = new WamEventRingBuffer(RingBuffer, this._mainToAudioSab,
-				this._parameterIndices);
+				parameterIds);
 			/** @private @type {WamEventRingBuffer} */
 			this._eventReader = new WamEventRingBuffer(RingBuffer, this._audioToMainSab,
-				this._parameterIndices);
+				parameterIds);
 
 			/** @private @type {number} */
 			this._eventReaderInterval = null;

--- a/packages/sdk/src/WamNode.js
+++ b/packages/sdk/src/WamNode.js
@@ -38,19 +38,19 @@ export default class WamNode extends AudioWorkletNode {
 
 		/** @type {WebAudioModule} */
 		this.module = module;
-		/** @type {boolean} _useSab */
+		/** @private @type {boolean} _useSab */
 		this._useSab = false; // can override this via processorOptions;
-		/** @type {boolean} _sabReady */
+		/** @private @type {boolean} _sabReady */
 		this._sabReady = false;
 		/** @private @type {{[key: number]: (...args: any[]) => any}} */
 		this._pendingResponses = {};
-		/**  @private @type {{[key: number]: () => any}} */
+		/** @private @type {{[key: number]: () => any}} */
 		this._pendingEvents = {};
-		/** @type {boolean} */
+		/** @private @type {boolean} */
 		this._destroyed = false;
-		/** @type {number} */
+		/** @private @type {number} */
 		this._messageId = 1;
-		/** @type {Set<WamEventType>} */
+		/** @private @type {Set<WamEventType>} */
 		this._supportedEventTypes = new Set(['wam-automation', 'wam-transport', 'wam-midi', 'wam-sysex', 'wam-mpe', 'wam-osc']);
 
 		this.port.onmessage = this._onMessage.bind(this);
@@ -306,25 +306,25 @@ export default class WamNode extends AudioWorkletNode {
 			this._useSab = true;
 			const { eventCapacity, parameterIndices } = sab;
 
-			/** @type {{[parameterId: string]: number}} */
+			/** @private @type {{[parameterId: string]: number}} */
 			this._parameterIndices = parameterIndices;
 
-			/** @type {SharedArrayBuffer} */
+			/** @private @type {SharedArrayBuffer} */
 			this._mainToAudioSab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer,
 				eventCapacity);
 
-			/** @type {SharedArrayBuffer} */
+			/** @private @type {SharedArrayBuffer} */
 			this._audioToMainSab = WamEventRingBuffer.getStorageForEventCapacity(RingBuffer,
 				eventCapacity);
 
-			/** @type {WamEventRingBuffer} */
+			/** @private @type {WamEventRingBuffer} */
 			this._eventWriter = new WamEventRingBuffer(RingBuffer, this._mainToAudioSab,
 				this._parameterIndices);
-			/** @type {WamEventRingBuffer} */
+			/** @private @type {WamEventRingBuffer} */
 			this._eventReader = new WamEventRingBuffer(RingBuffer, this._audioToMainSab,
 				this._parameterIndices);
 
-			/** @type {number} */
+			/** @private @type {number} */
 			this._eventReaderInterval = null;
 
 			const request = 'initialize/sab';

--- a/packages/sdk/src/WamProcessor.js
+++ b/packages/sdk/src/WamProcessor.js
@@ -124,14 +124,7 @@ export default class WamProcessor extends AudioWorkletProcessor {
 		this._useSab = !!useSab && !!globalThis.SharedArrayBuffer;
 		/** @private @type {boolean} */
 		this._sabReady = false;
-		if (this._useSab) {
-			/** @type {{[parameterId: string]: number}} */
-			this._parameterIndices = {};
-			Object.keys(this._parameterInfo).forEach((parameterId, index) => {
-				this._parameterIndices[parameterId] = index;
-			});
-			this._configureSab();
-		}
+		if (this._useSab) this._configureSab();
 	}
 
 	/**
@@ -180,6 +173,11 @@ export default class WamProcessor extends AudioWorkletProcessor {
 	}
 
 	_configureSab() {
+		/** @private @type {{[parameterId: string]: number}} */
+		this._parameterIndices = {};
+		Object.keys(this._parameterInfo).forEach((parameterId, index) => {
+			this._parameterIndices[parameterId] = index;
+		});
 		this.port.postMessage({
 			sab: {
 				eventCapacity: 2 ** 10,

--- a/packages/sdk/src/WamProcessor.js
+++ b/packages/sdk/src/WamProcessor.js
@@ -92,15 +92,15 @@ export default class WamProcessor extends AudioWorkletProcessor {
 		this.moduleId = moduleId;
 		/** @type {string} */
 		this.instanceId = instanceId;
-		/** @type {WamParameterInfoMap} */
+		/** @private @type {WamParameterInfoMap} */
 		// @ts-ignore
 		this._parameterInfo = this.constructor.generateWamParameterInfo();
-		/** @type {WamParameterMap} */
+		/** @private @type {WamParameterMap} */
 		this._parameterState = {};
-		/** @type {number} */
+		/** @private @type {number} */
 		this._samplesPerQuantum = 128;
 
-		/** @type {WamParameterInterpolatorMap} */
+		/** @private @type {WamParameterInterpolatorMap} */
 		this._parameterInterpolators = {};
 		Object.keys(this._parameterInfo).forEach((parameterId) => {
 			const info = this._parameterInfo[parameterId];
@@ -108,21 +108,21 @@ export default class WamProcessor extends AudioWorkletProcessor {
 			this._parameterInterpolators[parameterId] = new WamParameterInterpolator(info, 256);
 		});
 
-		/** @type {PendingWamEvent[]} */
+		/** @private @type {PendingWamEvent[]} */
 		this._eventQueue = [];
 
-		/** @type {number} */
+		/** @private @type {number} */
 		this._compensationDelay = 0;
-		/** @type {boolean} */
+		/** @private @type {boolean} */
 		this._destroyed = false;
 
 		webAudioModules.create(this);
 
 		this.port.onmessage = this._onMessage.bind(this);
 
-		/** @type {boolean} */
+		/** @private @type {boolean} */
 		this._useSab = !!useSab && !!globalThis.SharedArrayBuffer;
-		/** @type {boolean} */
+		/** @private @type {boolean} */
 		this._sabReady = false;
 		if (this._useSab) {
 			/** @type {{[parameterId: string]: number}} */
@@ -264,16 +264,16 @@ export default class WamProcessor extends AudioWorkletProcessor {
 				if (noun === 'sab') {
 					const { mainToAudioSab, audioToMainSab } = content;
 
-					/** @type {SharedArrayBuffer} */
+					/** @private @type {SharedArrayBuffer} */
 					this._audioToMainSab = audioToMainSab;
 
-					/** @type {SharedArrayBuffer} */
+					/** @private @type {SharedArrayBuffer} */
 					this._mainToAudioSab = mainToAudioSab;
 
-					/** @type {WamEventRingBuffer} */
+					/** @private @type {WamEventRingBuffer} */
 					this._eventWriter = new WamEventRingBuffer(RingBuffer, this._audioToMainSab,
 						this._parameterIndices);
-					/** @type {WamEventRingBuffer} */
+					/** @private @type {WamEventRingBuffer} */
 					this._eventReader = new WamEventRingBuffer(RingBuffer, this._mainToAudioSab,
 						this._parameterIndices);
 

--- a/packages/sdk/src/api/types.d.ts
+++ b/packages/sdk/src/api/types.d.ts
@@ -232,28 +232,30 @@ export interface WamBinaryData {
     bytes: Uint8Array;
 }
 
+export interface WamInfoData {
+    instanceId: string;
+}
+
 export type WamEventCallback<E extends WamEventType = WamEventType> = (event: WamEventMap[E]) => any;
 
 export interface WamEventMap {
-    'wam-event': WamGeneralEvent;
     'wam-automation': WamAutomationEvent;
     'wam-transport': WamTransportEvent;
     'wam-midi': WamMidiEvent;
     'wam-sysex': WamSysexEvent;
     'wam-mpe': WamMpeEvent;
     'wam-osc': WamOscEvent;
-    'wam-parameter-info': WamParameterInfoEvent;
+    'wam-info': WamInfoEvent;
 }
 
-export type WamEvent = WamGeneralEvent | WamAutomationEvent | WamTransportEvent | WamMidiEvent | WamSysexEvent | WamMpeEvent | WamOscEvent | WamParameterInfoEvent;
-export type WamGeneralEvent = WamEventBase<'wam-event', WamParameterData>;
+export type WamEvent = WamAutomationEvent | WamTransportEvent | WamMidiEvent | WamSysexEvent | WamMpeEvent | WamOscEvent | WamInfoEvent;
 export type WamAutomationEvent = WamEventBase<'wam-automation', WamParameterData>;
 export type WamTransportEvent = WamEventBase<'wam-transport', WamTransportData>;
 export type WamMidiEvent = WamEventBase<'wam-midi', WamMidiData>;
 export type WamSysexEvent = WamEventBase<'wam-sysex', WamBinaryData>;
 export type WamMpeEvent = WamEventBase<'wam-mpe', WamMidiData>;
 export type WamOscEvent = WamEventBase<'wam-osc', WamBinaryData>;
-export type WamParameterInfoEvent = WamEventBase<'wam-parameter-info', string[]>;
+export type WamInfoEvent = WamEventBase<'wam-info', WamInfoData>;
 
 export interface AudioWorkletProcessor {
     port: MessagePort;

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -133,9 +133,10 @@ export interface WamEventRingBuffer {
 	/**
 	 * In case parameter set changes, update the internal mappings.
 	 * May result in some invalid automation events, which will be
-	 * ignored.
+	 * ignored. Note that this must be called on corresponding
+	 * WamEventRingBuffers on both threads.
 	 */
-	 setParameterIndices(parameterIndices: Record<string, number>);
+	 setParameterIds(parameterIds: string[]);
 }
 export const WamEventRingBuffer: {
 	prototype: WamEventRingBuffer;
@@ -204,7 +205,7 @@ export const WamEventRingBuffer: {
 	 * a UInt8Array RingBuffer. Specify 'maxBytesPerEvent'
 	 * to support variable-size binary event types like sysex or osc.
 	 */
-	new (RingBufferConstructor: typeof RingBuffer, sab: SharedArrayBuffer, parameterIndices: { [parameterId: string]: number }, maxBytesPerEvent?: number): WamEventRingBuffer;
+	new (RingBufferConstructor: typeof RingBuffer, sab: SharedArrayBuffer, parameterIds: string[], maxBytesPerEvent?: number): WamEventRingBuffer;
 };
 
 export interface AudioWorkletGlobalScope extends IAudioWorkletGlobalScope {

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -139,6 +139,13 @@ export interface WamEventRingBuffer {
 }
 export const WamEventRingBuffer: {
 	prototype: WamEventRingBuffer;
+
+	/**
+	 * Default number of additional bytes allocated
+	 * per event (to support variable-size event objects)
+	 */
+	DefaultExtraBytesPerEvent: number;
+
 	/**
 	 * Number of bytes required for WamEventBase
 	 * {uint32} total event size in bytes

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -129,6 +129,13 @@ export interface WamEventRingBuffer {
 	 * the list of events successfully read.
 	 */
 	read(): WamEvent[];
+
+	/**
+	 * In case parameter set changes, update the internal mappings.
+	 * May result in some invalid automation events, which will be
+	 * ignored.
+	 */
+	 setParameterIndices(parameterIndices: Record<string, number>);
 }
 export const WamEventRingBuffer: {
 	prototype: WamEventRingBuffer;


### PR DESCRIPTION
Changing what was `wam-parameter-info` event to `wam-info` event
updating relevant packages:
- host
- pedalboard
- WamNode / WamProcessor
- WamEventRingBuffer