### PR TITLE
add 'prepack' script hook to build sdk when installed directly from github

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "clean": "del-cli esm",
     "build": "rollup -c",
-    "test": "jest"
+    "test": "jest",
+    "prepack": "yarn build"
   }
 }


### PR DESCRIPTION
yarn will run the 'prepack' script when the package has been installed directly from github.  With this 1-liner change, other projects can install the webaudiomodule sdk by doing the following:

upgrade their project to use yarn 2 - https://next.yarnpkg.com/getting-started/migration#step-by-step

add the sdk to yarn with the following syntax: `yarn add sdk@53js/webaudiomodule#workspace=sdk`

The only way I've found to adjust the dependency to a specific commit is to then edit yarn.lock to point to the specific commit (and remove the checksum line, yarn will add it back after fetching the new commit)
