### PR TITLE
Add a 'run' flag to WamTransportData to indicate if transport is currently running

### DIFF
--- a/packages/sdk/__test__/WamEventRingBuffer.spec.ts
+++ b/packages/sdk/__test__/WamEventRingBuffer.spec.ts
@@ -38,6 +38,7 @@ describe('WamEventRingBuffer Suite', () => {
 			tempo: 120,
 			timeSigNumerator: 3,
 			timeSigDenominator: 4,
+			playing: true,
 		},
 	};
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "clean": "del-cli esm",
     "build": "rollup -c",
-    "test": "jest"
+    "test": "jest",
+    "prepack": "yarn build"
   }
 }

--- a/packages/sdk/src/WamEventRingBuffer.js
+++ b/packages/sdk/src/WamEventRingBuffer.js
@@ -69,10 +69,11 @@ const executable = () => {
 		 * {float64} tempo
 		 * {uint8} time signature numerator
 		 * {uint8} time signature denominator
+		 * {uint8} run flags
 		 *
 		 * @type {number}
 		 */
-		static WamTransportEventBytes = WamEventRingBuffer.WamEventBaseBytes + 4 + 8 + 8 + 1 + 1;
+		static WamTransportEventBytes = WamEventRingBuffer.WamEventBaseBytes + 4 + 8 + 8 + 1 + 1 + 1;
 
 		/**
 		 * Number of bytes required for WamMidiEvent or WamMpeEvent
@@ -255,7 +256,7 @@ const executable = () => {
 				 */
 				const { data } = event;
 				const {
-					currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator,
+					currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator, runFlags
 				} = data;
 
 				this._eventBytesView.setUint32(byteOffset, currentBar);
@@ -267,6 +268,8 @@ const executable = () => {
 				this._eventBytesView.setUint8(byteOffset, timeSigNumerator);
 				byteOffset += 1;
 				this._eventBytesView.setUint8(byteOffset, timeSigDenominator);
+				byteOffset += 1;
+				this._eventBytesView.setUint8(byteOffset, runFlags);
 				byteOffset += 1;
 			} break;
 			case 'wam-mpe':
@@ -373,13 +376,15 @@ const executable = () => {
 				byteOffset += 1;
 				const timeSigDenominator = this._eventBytesView.getUint8(byteOffset);
 				byteOffset += 1;
+				const runFlags = this._eventBytesView.getUint8(byteOffset);
+				byteOffset += 1;
 
 				/** @type {WamTransportEvent} */
 				const event = {
 					type,
 					time,
 					data: {
-						currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator,
+						currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator, runFlags
 					},
 				};
 				return event;

--- a/packages/sdk/src/WamEventRingBuffer.js
+++ b/packages/sdk/src/WamEventRingBuffer.js
@@ -69,7 +69,7 @@ const executable = () => {
 		 * {float64} tempo
 		 * {uint8} time signature numerator
 		 * {uint8} time signature denominator
-		 * {uint8} run flags
+		 * {uint8} playing flag
 		 *
 		 * @type {number}
 		 */
@@ -256,7 +256,7 @@ const executable = () => {
 				 */
 				const { data } = event;
 				const {
-					currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator, runFlags
+					currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator, playing
 				} = data;
 
 				this._eventBytesView.setUint32(byteOffset, currentBar);
@@ -269,7 +269,7 @@ const executable = () => {
 				byteOffset += 1;
 				this._eventBytesView.setUint8(byteOffset, timeSigDenominator);
 				byteOffset += 1;
-				this._eventBytesView.setUint8(byteOffset, runFlags);
+				this._eventBytesView.setUint8(byteOffset, playing ? 1 : 0);
 				byteOffset += 1;
 			} break;
 			case 'wam-mpe':
@@ -376,7 +376,7 @@ const executable = () => {
 				byteOffset += 1;
 				const timeSigDenominator = this._eventBytesView.getUint8(byteOffset);
 				byteOffset += 1;
-				const runFlags = this._eventBytesView.getUint8(byteOffset);
+				const playing = (this._eventBytesView.getUint8(byteOffset) == 1);
 				byteOffset += 1;
 
 				/** @type {WamTransportEvent} */
@@ -384,7 +384,7 @@ const executable = () => {
 					type,
 					time,
 					data: {
-						currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator, runFlags
+						currentBar, currentBarStarted, tempo, timeSigNumerator, timeSigDenominator, playing
 					},
 				};
 				return event;

--- a/packages/sdk/src/api/types.d.ts
+++ b/packages/sdk/src/api/types.d.ts
@@ -222,8 +222,8 @@ export interface WamTransportData {
     timeSigNumerator: number;
     /** Beat duration indicator */
     timeSigDenominator: number;
-    /** Run state flags: 0x01 == PLAYING */
-    runFlags: number;
+    /** Determines if transport is active */
+    playing: boolean;
 }
 
 export interface WamMidiData {

--- a/packages/sdk/src/api/types.d.ts
+++ b/packages/sdk/src/api/types.d.ts
@@ -222,6 +222,8 @@ export interface WamTransportData {
     timeSigNumerator: number;
     /** Beat duration indicator */
     timeSigDenominator: number;
+    /** Run state flags: 0x01 == PLAYING */
+    runFlags: number;
 }
 
 export interface WamMidiData {


### PR DESCRIPTION
Pretty self-explanatory.  I could see the 'flags' being used to also indicate if transport is paused as a third state, but didn't implement that here.

This PR sits on top of #65, that commit's here as well.