### PR TITLE
Fix regression in _getParameterValues, if parameterIds array is empty use all parameters

### DIFF
--- a/packages/sdk/src/WamProcessor.js
+++ b/packages/sdk/src/WamProcessor.js
@@ -334,7 +334,7 @@ export default class WamProcessor extends AudioWorkletProcessor {
 	_getParameterValues(normalized, parameterIds) {
 		/** @type {WamParameterDataMap} */
 		const parameterValues = {};
-		if (!parameterIds) parameterIds = Object.keys(this._parameterState);
+		if (!parameterIds || !parameterIds.length) parameterIds = Object.keys(this._parameterState);
 		let i = 0;
 		while (i < parameterIds.length) {
 			const id = parameterIds[i];


### PR DESCRIPTION
@owengc please review

I believe this functionality was accidentally removed in ee22c00770c2eade4b44b57388879ce28670c20f

If one calls `getParameterValues()` from the main thread it used to return values for all parameters