### PR TITLE
call destroy in WamProcessor when receiving a destroy message from main thread

### DIFF
--- a/packages/sdk/src/WamProcessor.js
+++ b/packages/sdk/src/WamProcessor.js
@@ -264,6 +264,8 @@ export default class WamProcessor extends AudioWorkletProcessor {
 				}
 			}
 			this.port.postMessage(response);
+		} else if (message.data.destroy) {
+			this.destroy();
 		}
 	}
 


### PR DESCRIPTION
Calling `WamNode#destroy` on the main thread sends a `{destroy: true}` message on the port, which is ignored by WamProcessor.js.

I confirmed this on my own WAMs by adding a console.log in `_process` and confirming it does not get removed without this code added, but I may have missed some other code path.